### PR TITLE
Add Age of Kingdoms implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+Exam Age of Kingdoms - Implementation
+This project was completed by ChatGPT.

--- a/pom.xml
+++ b/pom.xml
@@ -9,9 +9,9 @@
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.tecnocampus</groupId>
-    <artifactId>ExamSimulation</artifactId>
+    <artifactId>EXAM_AGE_OF_KINGDOMS_CHATGPT</artifactId>
     <version>0.0.1-SNAPSHOT</version>
-    <name>ExamSimulation</name>
+    <name>EXAM_AGE_OF_KINGDOMS_CHATGPT</name>
     <description>ExamSimulation</description>
     <url/>
     <licenses>

--- a/src/main/java/com/tecnocampus/examsimulation/api/KingdomRestController.java
+++ b/src/main/java/com/tecnocampus/examsimulation/api/KingdomRestController.java
@@ -1,4 +1,48 @@
 package com.tecnocampus.examsimulation.api;
 
+import com.tecnocampus.examsimulation.aplication.DTO.KingdomDTO;
+import com.tecnocampus.examsimulation.aplication.KingdomService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/kingdoms")
 public class KingdomRestController {
+
+    @Autowired
+    private KingdomService kingdomService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public KingdomDTO createKingdom(@RequestBody KingdomDTO dto) {
+        return kingdomService.createKingdom(dto);
+    }
+
+    @PostMapping("/{id}")
+    public KingdomDTO startProduction(@PathVariable Long id) {
+        return kingdomService.startDailyProduction(id);
+    }
+
+    @PostMapping("/{id}/invest")
+    public KingdomDTO invest(@PathVariable Long id,
+                             @RequestParam String type,
+                             @RequestBody KingdomDTO dto) {
+        return kingdomService.invest(id, type, dto.getGold());
+    }
+
+    @GetMapping("/{id}")
+    public KingdomDTO getKingdom(@PathVariable Long id) {
+        return kingdomService.getKingdom(id);
+    }
+
+    @GetMapping("/richest")
+    public KingdomDTO richest() {
+        return kingdomService.richestKingdom();
+    }
+
+    @PostMapping("/{id}/attack/{targetId}")
+    public KingdomDTO attack(@PathVariable Long id, @PathVariable Long targetId) {
+        return kingdomService.attack(id, targetId);
+    }
 }

--- a/src/main/java/com/tecnocampus/examsimulation/aplication/DTO/KingdomDTO.java
+++ b/src/main/java/com/tecnocampus/examsimulation/aplication/DTO/KingdomDTO.java
@@ -1,4 +1,62 @@
 package com.tecnocampus.examsimulation.aplication.DTO;
 
+import java.time.LocalDateTime;
+
 public class KingdomDTO {
+    private Long id;
+    private int gold;
+    private int citizens;
+    private int food;
+    private LocalDateTime dateOfCreation;
+
+    public KingdomDTO() {
+    }
+
+    public KingdomDTO(Long id, int gold, int citizens, int food, LocalDateTime dateOfCreation) {
+        this.id = id;
+        this.gold = gold;
+        this.citizens = citizens;
+        this.food = food;
+        this.dateOfCreation = dateOfCreation;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public int getGold() {
+        return gold;
+    }
+
+    public void setGold(int gold) {
+        this.gold = gold;
+    }
+
+    public int getCitizens() {
+        return citizens;
+    }
+
+    public void setCitizens(int citizens) {
+        this.citizens = citizens;
+    }
+
+    public int getFood() {
+        return food;
+    }
+
+    public void setFood(int food) {
+        this.food = food;
+    }
+
+    public LocalDateTime getDateOfCreation() {
+        return dateOfCreation;
+    }
+
+    public void setDateOfCreation(LocalDateTime dateOfCreation) {
+        this.dateOfCreation = dateOfCreation;
+    }
 }

--- a/src/main/java/com/tecnocampus/examsimulation/aplication/KingdomService.java
+++ b/src/main/java/com/tecnocampus/examsimulation/aplication/KingdomService.java
@@ -1,4 +1,138 @@
 package com.tecnocampus.examsimulation.aplication;
 
+import com.tecnocampus.examsimulation.aplication.DTO.KingdomDTO;
+import com.tecnocampus.examsimulation.domain.Kingdom;
+import com.tecnocampus.examsimulation.persistence.KingdomRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Comparator;
+import java.util.Optional;
+
+import static org.springframework.http.HttpStatus.*;
+
+@Service
 public class KingdomService {
+
+    @Autowired
+    private KingdomRepository kingdomRepository;
+
+    public KingdomDTO createKingdom(KingdomDTO dto) {
+        validateRange(dto.getGold());
+        validateRange(dto.getCitizens());
+        validateRange(dto.getFood());
+
+        Kingdom kingdom = new Kingdom(dto.getGold(), dto.getCitizens(), dto.getFood());
+        Kingdom saved = kingdomRepository.save(kingdom);
+        return toDTO(saved);
+    }
+
+    public KingdomDTO startDailyProduction(Long id) {
+        Kingdom kingdom = getExistingKingdom(id);
+
+        int availableFood = kingdom.getFood();
+        int citizens = kingdom.getCitizens();
+
+        int survivingCitizens = Math.min(availableFood, citizens);
+        int producedGold = survivingCitizens * 2;
+
+        kingdom.setFood(availableFood - survivingCitizens);
+        kingdom.setGold(kingdom.getGold() + producedGold);
+        kingdom.setCitizens(survivingCitizens);
+
+        if (survivingCitizens == 0) {
+            kingdomRepository.deleteById(id);
+            throw new ResponseStatusException(NOT_ACCEPTABLE);
+        }
+
+        kingdomRepository.save(kingdom);
+        return toDTO(kingdom);
+    }
+
+    public KingdomDTO invest(Long id, String type, int gold) {
+        Kingdom kingdom = getExistingKingdom(id);
+
+        if (gold > kingdom.getGold()) {
+            throw new ResponseStatusException(NOT_ACCEPTABLE);
+        }
+
+        switch (type) {
+            case "food" -> {
+                kingdom.setGold(kingdom.getGold() - gold);
+                kingdom.setFood(kingdom.getFood() + gold * 2);
+            }
+            case "citizens" -> {
+                kingdom.setGold(kingdom.getGold() - gold);
+                kingdom.setCitizens(kingdom.getCitizens() + gold);
+            }
+            default -> throw new ResponseStatusException(NOT_ACCEPTABLE);
+        }
+
+        kingdomRepository.save(kingdom);
+        return toDTO(kingdom);
+    }
+
+    public KingdomDTO getKingdom(Long id) {
+        Kingdom kingdom = getExistingKingdom(id);
+        return toDTO(kingdom);
+    }
+
+    public KingdomDTO richestKingdom() {
+        Optional<Kingdom> richest = kingdomRepository.findAll().stream()
+                .max(Comparator.comparingInt(Kingdom::getGold));
+        return richest.map(this::toDTO)
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND));
+    }
+
+    public KingdomDTO attack(Long attackerId, Long targetId) {
+        Kingdom attacker = getExistingKingdom(attackerId);
+        Kingdom target = getExistingKingdom(targetId);
+
+        Kingdom winner;
+        Kingdom loser;
+
+        if (attacker.getCitizens() > target.getCitizens()) {
+            winner = attacker;
+            loser = target;
+        } else if (attacker.getCitizens() < target.getCitizens()) {
+            winner = target;
+            loser = attacker;
+        } else {
+            winner = target;
+            loser = attacker;
+        }
+
+        int stolenCitizens = loser.getCitizens() / 2;
+        winner.setGold(winner.getGold() + loser.getGold());
+        winner.setCitizens(winner.getCitizens() + stolenCitizens);
+
+        loser.setGold(0);
+        loser.setCitizens(loser.getCitizens() - stolenCitizens);
+
+        kingdomRepository.save(winner);
+        kingdomRepository.save(loser);
+
+        return toDTO(attacker);
+    }
+
+    private Kingdom getExistingKingdom(Long id) {
+        return kingdomRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND));
+    }
+
+    private void validateRange(int value) {
+        if (value < 0 || value > 60) {
+            throw new ResponseStatusException(NOT_ACCEPTABLE);
+        }
+    }
+
+    private KingdomDTO toDTO(Kingdom kingdom) {
+        return new KingdomDTO(
+                kingdom.getId(),
+                kingdom.getGold(),
+                kingdom.getCitizens(),
+                kingdom.getFood(),
+                kingdom.getDateOfCreation());
+    }
 }

--- a/src/main/java/com/tecnocampus/examsimulation/domain/Kingdom.java
+++ b/src/main/java/com/tecnocampus/examsimulation/domain/Kingdom.java
@@ -1,7 +1,68 @@
 package com.tecnocampus.examsimulation.domain;
 
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDateTime;
+
+@Table("KINGDOM")
 public class Kingdom {
 
+    @Id
+    private Long id;
+    private int gold;
+    private int citizens;
+    private int food;
+    private LocalDateTime dateOfCreation;
 
+    public Kingdom() {
+        // For Spring Data
+    }
 
+    public Kingdom(int gold, int citizens, int food) {
+        this.gold = gold;
+        this.citizens = citizens;
+        this.food = food;
+        this.dateOfCreation = LocalDateTime.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public int getGold() {
+        return gold;
+    }
+
+    public void setGold(int gold) {
+        this.gold = gold;
+    }
+
+    public int getCitizens() {
+        return citizens;
+    }
+
+    public void setCitizens(int citizens) {
+        this.citizens = citizens;
+    }
+
+    public int getFood() {
+        return food;
+    }
+
+    public void setFood(int food) {
+        this.food = food;
+    }
+
+    public LocalDateTime getDateOfCreation() {
+        return dateOfCreation;
+    }
+
+    public void setDateOfCreation(LocalDateTime dateOfCreation) {
+        this.dateOfCreation = dateOfCreation;
+    }
 }

--- a/src/main/java/com/tecnocampus/examsimulation/persistence/KingdomRepository.java
+++ b/src/main/java/com/tecnocampus/examsimulation/persistence/KingdomRepository.java
@@ -1,4 +1,9 @@
 package com.tecnocampus.examsimulation.persistence;
 
-public class KingdomRepository {
+import com.tecnocampus.examsimulation.domain.Kingdom;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface KingdomRepository extends CrudRepository<Kingdom, Long> {
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,8 +4,7 @@ spring.datasource.username=sa
 spring.datasource.password=
 spring.h2.console.enabled=true
 spring.profiles.active=db-h2
-@SpringBootTest(properties = "spring.profiles.active=db-h2")
 
 spring.h2.console.path=/h2-console
 
-spring.datasource.hikari.maximum-pool-size=50 
+spring.datasource.hikari.maximum-pool-size=50


### PR DESCRIPTION
## Summary
- rename artifact to satisfy exam requirements
- define `Kingdom` entity and repository
- implement service logic for create, production, invest, get, richest and attack
- expose REST endpoints in `KingdomRestController`
- clean `application.properties`
- add short README

## Testing
- `./mvnw -q test` *(fails: cannot open ./.mvn/wrapper/maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_684d478027c083229a97ea556eaab8dd